### PR TITLE
bug/Documents, Profile and Pagination fixes

### DIFF
--- a/Client/public/assets/icons/pagination/ArrowBackIcon.tsx
+++ b/Client/public/assets/icons/pagination/ArrowBackIcon.tsx
@@ -1,0 +1,14 @@
+const ArrowBackIcon = () => {
+	return (
+		<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M12.8332 6.99984H1.1665M1.1665 6.99984L6.99984 12.8332M1.1665 6.99984L6.99984 1.1665"
+				stroke="#667085"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	);
+};
+
+export default ArrowBackIcon;

--- a/Client/public/assets/icons/pagination/ArrowForwardIcon.tsx
+++ b/Client/public/assets/icons/pagination/ArrowForwardIcon.tsx
@@ -1,0 +1,14 @@
+const ArrowForwardIcon = () => {
+	return (
+		<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M1.16699 6.99984H12.8337M12.8337 6.99984L7.00033 1.1665M12.8337 6.99984L7.00033 12.8332"
+				stroke="#667085"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	);
+};
+
+export default ArrowForwardIcon;

--- a/Client/src/app/documents/components/DocumentsTableRow.tsx
+++ b/Client/src/app/documents/components/DocumentsTableRow.tsx
@@ -39,12 +39,12 @@ const DocumentsTableRow = ({ document }: Props) => {
 
 	return (
 		<TableRow hover>
-			<TableCell sx={{ paddingRight: 0 }}>
+			<TableCell sx={{ paddingRight: 0, textAlign: 'center' }}>
 				<Box
 					component="img"
 					src={docTypeIcons[document.type]}
 					alt={`${document.type} icon`}
-					sx={{ width: '24px', height: '24px' }}
+					sx={{ width: 24, height: 24 }}
 				/>
 			</TableCell>
 			<TableCell>

--- a/Client/src/app/documents/components/DragAndDropBox.tsx
+++ b/Client/src/app/documents/components/DragAndDropBox.tsx
@@ -24,32 +24,31 @@ const DragAndDropBox = ({ text, height }: DragAndDropBoxProps) => {
 	// };
 
 	return (
-		<Box
-			sx={{
-				border: '2px dashed rgba(236, 236, 236)',
-				borderRadius: '4px',
-				padding: '2rem',
-				textAlign: 'center',
-				backgroundColor: 'rgba(255, 255, 255, 0.6)',
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'center',
-				flexDirection: 'column',
-				cursor: 'pointer',
-				height: { height },
-			}}>
+		<>
 			<Box
-				component="img"
-				src="/assets/icons/documentPage/document-upload-icon.svg"
-				alt="Document Icon"
-				sx={{ width: '8rem', height: '8rem', marginBottom: '1rem' }}
-			/>
-			<Button color="inherit" onClick={openModal}>
-				{text}
-			</Button>
-
-			<input type="file" id="file-input" style={{ display: 'none' }} onChange={handleInput} />
-
+				onClick={openModal}
+				sx={{
+					border: '2px dashed rgba(236, 236, 236)',
+					borderRadius: 2,
+					padding: '2rem',
+					textAlign: 'center',
+					backgroundColor: 'rgba(255, 255, 255, 0.6)',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					flexDirection: 'column',
+					cursor: 'pointer',
+					height: { height },
+				}}>
+				<Box
+					component="img"
+					src="/assets/icons/documentPage/document-upload-icon.svg"
+					alt="Document Icon"
+					sx={{ width: '8rem', height: '8rem', mb: '0.5rem' }}
+				/>
+				<Button color="inherit">{text}</Button>
+				<input type="file" id="file-input" style={{ display: 'none' }} onChange={handleInput} />
+			</Box>
 			<ModalWrapper
 				variant="upload"
 				title="Upload a new file"
@@ -60,7 +59,7 @@ const DragAndDropBox = ({ text, height }: DragAndDropBoxProps) => {
 				maxFileSize="50"
 				fileFormats="PDF"
 			/>
-		</Box>
+		</>
 	);
 };
 

--- a/Client/src/app/documents/components/DragAndDropBox.tsx
+++ b/Client/src/app/documents/components/DragAndDropBox.tsx
@@ -8,7 +8,7 @@ interface DragAndDropBoxProps {
 	height?: string;
 }
 
-const DragAndDropBox = ({ text, height }: DragAndDropBoxProps) => {
+const DragAndDropBox = ({ text, height = '32vh' }: DragAndDropBoxProps) => {
 	const { isOpen, openModal, closeModal } = useModal();
 
 	const handleInput = () => {

--- a/Client/src/app/documents/page.tsx
+++ b/Client/src/app/documents/page.tsx
@@ -85,16 +85,10 @@ export default function DocumentsPage() {
 							<Typography variant="h3">Manage your documents</Typography>
 							<Typography variant="body1">{documentCount} documents</Typography>
 						</Box>
-						<Button variant="contained" color="primary" size="medium">
-							Upload new document
-						</Button>
 					</Box>
 					{/* Drag-and-Drop Section */}
 					<Box mb={5} width="100%">
-						<DragAndDropBox
-							height="21vh"
-							text="Drag and drop your document here or click to upload"
-						/>
+						<DragAndDropBox text="Drag and drop your document here or click to upload" />
 					</Box>
 
 					{/* Documents Table Section */}

--- a/Client/src/app/profile/page.tsx
+++ b/Client/src/app/profile/page.tsx
@@ -8,7 +8,7 @@ export default function ProfilePage() {
 				width: '100%',
 				margin: '0 auto',
 				minHeight: '80vh',
-				paddingRight: '8rem',
+				paddingRight: '23rem',
 			}}>
 			<ProfileClient />
 		</Box>

--- a/Client/src/components/Paginator.tsx
+++ b/Client/src/components/Paginator.tsx
@@ -1,6 +1,6 @@
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { Box, Button, Pagination, PaginationItem } from '@mui/material';
+import ArrowBackIcon from '../../public/assets/icons/pagination/ArrowBackIcon';
+import ArrowForwardIcon from '../../public/assets/icons/pagination/ArrowForwardIcon';
 
 interface PaginatorProps {
 	page: number;
@@ -10,13 +10,7 @@ interface PaginatorProps {
 	totalItems: number;
 }
 
-const Paginator = ({
-	page,
-	totalPages,
-	onPageChange,
-	pageSize,
-	totalItems,
-}: PaginatorProps) => {
+const Paginator = ({ page, totalPages, onPageChange, pageSize, totalItems }: PaginatorProps) => {
 	const handlePageChange = (_event: any, newPage: number) => {
 		onPageChange(newPage);
 	};
@@ -26,12 +20,7 @@ const Paginator = ({
 	}
 
 	return (
-		<Box
-			display="flex"
-			justifyContent="center"
-			alignItems="center"
-			marginTop="1rem"
-			gap="5rem">
+		<Box display="flex" justifyContent="center" alignItems="center" marginTop="1rem" gap="5rem">
 			<Button
 				variant="outlined"
 				color="secondary"
@@ -51,9 +40,7 @@ const Paginator = ({
 				onChange={handlePageChange}
 				shape="rounded"
 				color="secondary"
-				renderItem={(item) => (
-					<PaginationItem {...item} sx={{ padding: '0 8px' }} />
-				)}
+				renderItem={(item) => <PaginationItem {...item} sx={{ padding: '0 8px' }} />}
 			/>
 			<Button
 				variant="outlined"


### PR DESCRIPTION
Issues #69, #73 and #75 are completed:

Documents page:

- Removing "Upload new document" button.
- The whole rectangular section for "Drag and Drop Box" is clickable.
- All the icons in the document list are center.
- fixing padding and height styles for the box of the drag and drop component.

Profile Page:

- the layout is like Figma now.

Pagination component:

- Exporting icons from Figma.
- Adding them as SVG files.
- Converting the SVG files to React Components called ArrowForwardIcon.tsx and ArrowBackIcon.tsx with "1px" stroke by default.
- Updating the Paginator.tsx.

Figma: 
<img width="103" alt="FigmaArrowBackIcon" src="https://github.com/user-attachments/assets/e75421dd-ceb5-4942-9ea3-c00e0e8e3446">

Designed: 
<img width="116" alt="DesignedArrowBackIcon" src="https://github.com/user-attachments/assets/8d46a6a1-522c-48bf-a25b-101f046d0cb2">


<img width="751" alt="Documents" src="https://github.com/user-attachments/assets/0e8e9173-cbdf-48b9-a8ab-01c56d1e4515">

<img width="805" alt="Profile" src="https://github.com/user-attachments/assets/6b64f6ea-0cd7-464e-88f7-a60f51905d9a">
