### PR TITLE
feat/new upload modal

### DIFF
--- a/Client/src/app/profile/components/ProfileForm.tsx
+++ b/Client/src/app/profile/components/ProfileForm.tsx
@@ -241,7 +241,7 @@ export default function ProfileForm() {
 				confirmButtonText='Update'
 				open={uploadModal.isOpen}
 				onClose={handleUpdatePhoto}
-				maxFileSize='3'
+				maxFileSize='3 MB'
 				fileFormats='JPG, PNG'
 				toggleModal={uploadModal.closeModal}
 			/>

--- a/Client/src/app/settings/components/BrandingSetting.tsx
+++ b/Client/src/app/settings/components/BrandingSetting.tsx
@@ -187,7 +187,7 @@ export default function BrandingSetting() {
 				confirmButtonText='Update'
 				open={uploadModal.isOpen}
 				onClose={handleUpdate}
-				maxFileSize='3'
+				maxFileSize='3 MB'
 				fileFormats='JPG, PNG'
 				toggleModal={uploadModal.closeModal}
 			/>

--- a/Client/src/components/CustomCircularProgress.tsx
+++ b/Client/src/components/CustomCircularProgress.tsx
@@ -1,0 +1,54 @@
+import { Box, CircularProgress, CircularProgressProps, Typography } from '@mui/material';
+import { useEffect} from 'react';
+
+const CircularProgressWithLabel = (props: CircularProgressProps & { value: number }) => {
+	return (
+		<Box sx={{ position: 'relative', display: 'inline-flex' }}>
+			<CircularProgress
+				variant='determinate'
+				{...props}
+			/>
+			<Box
+				sx={{
+					top: 0,
+					left: 0,
+					bottom: 0,
+					right: 0,
+					position: 'absolute',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+				}}>
+				<Typography
+					variant='caption'
+					component='div'
+					sx={{ color: 'text.secondary' }}>{`${Math.round(props.value)}%`}</Typography>
+			</Box>
+		</Box>
+	);
+};
+
+interface CustomCircularProgressProps {
+	fileInfo: { name: string; size: string; type: string };
+	progress: number;
+	handleProgress: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const CustomCircularProgress = ({
+	fileInfo,
+	progress,
+	handleProgress,
+}: CustomCircularProgressProps) => {
+	useEffect(() => {
+		const timer = setInterval(() => {
+			handleProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 10));
+		}, 800);
+		return () => {
+			clearInterval(timer);
+		};
+	}, [fileInfo.name]);
+
+	return <CircularProgressWithLabel value={progress} />;
+};
+
+export default CustomCircularProgress;

--- a/Client/src/components/CustomUploader.tsx
+++ b/Client/src/components/CustomUploader.tsx
@@ -1,0 +1,125 @@
+import useFileInfo from '@/hooks/useFileInfo';
+import { useToast } from '@/hooks/useToast';
+import { Box, Button, TextField } from '@mui/material';
+import axios from 'axios';
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+
+interface CustomUploaderProps {
+	fileFormats?: string;
+	fileInfo: { name: string; size: string; type: string };
+	handleFileInfo: React.Dispatch<
+		React.SetStateAction<{ name: string; size: string; type: string }>
+	>;
+}
+
+export default function CustomUploader({
+	fileFormats,
+	fileInfo,
+	handleFileInfo,
+}: CustomUploaderProps) {
+	const [uploading, setUploading] = useState(false);
+	const { data: session } = useSession();
+	const { showToast } = useToast();
+	const { formatFileSize } = useFileInfo();
+
+	const handleUploadFile = () => {
+		console.log('File Uploaded Successfully!');
+		showToast({
+			message: 'File Uploaded Successfully!',
+			variant: 'success',
+		});
+	};
+
+	const handleFailedFileError = () => {
+		console.log('File Uploading Failed!');
+		showToast({
+			message: 'File Uploading Failed!',
+			variant: 'error',
+		});
+	};
+
+	const handleNotAuthenticatedError = () => {
+		console.log('User not authenticated!');
+		showToast({
+			message: 'User not authenticated!',
+			variant: 'error',
+		});
+	};
+
+	// Handle file selection
+	const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+
+		if (file) {
+			const formattedFileSize = formatFileSize(file.size);
+			handleFileInfo((prevFileInfo) => ({
+				...prevFileInfo,
+				name: file.name,
+				size: formattedFileSize,
+				type: file.type,
+			}));
+		} else {
+			return;
+		}
+
+		setUploading(true);
+
+		try {
+			if (!session) {
+				console.error('User not authenticated!');
+				handleNotAuthenticatedError();
+				setUploading(false);
+				return;
+			}
+
+			const formData = new FormData();
+			formData.append('file', file);
+
+			const response = await axios.post('/api/documents/upload', formData);
+
+			if (response?.status === 200 && response.data?.document) {
+				handleUploadFile();
+			} else {
+				handleFailedFileError();
+			}
+		} catch (error: any) {
+			const errorMessage =
+				error.response?.data?.error || error.message || 'Unexpected error occurred';
+			console.error('Error uploading file:', errorMessage, error);
+			handleFailedFileError();
+		} finally {
+			setUploading(false);
+		}
+	};
+
+	return (
+		<Box display='flex'>
+			<TextField
+				value={fileInfo.name}
+				size='small'
+				fullWidth
+			/>
+			<Button
+				variant='outlined'
+				color='inherit'
+				size='small'
+				sx={{
+					borderColor: 'text.notes',
+					ml: 10,
+					fontSize: 13,
+					minWidth: '6rem',
+				}}
+				onClick={() => document.getElementById('file-input')?.click()}>
+				Browse
+			</Button>
+			<input
+				type='file'
+				id='file-input'
+				accept={fileFormats === 'JPG, PNG' ? 'image/*' : 'application/pdf'}
+				style={{ display: 'none' }}
+				onChange={handleFileSelect}
+			/>
+		</Box>
+	);
+}

--- a/Client/src/hooks/useFileInfo.ts
+++ b/Client/src/hooks/useFileInfo.ts
@@ -1,0 +1,43 @@
+export default function useFileInfo() {
+	// Convert a size in bytes to a human-readable size string (e.g., "5 MB").
+	const formatFileSize = (sizeInBytes: number): string => {
+		if (sizeInBytes < 1024) {
+			return `${sizeInBytes} Bytes`;
+		} else if (sizeInBytes < 1024 * 1024) {
+			return `${(sizeInBytes / 1024).toFixed(2)} KB`;
+		} else if (sizeInBytes < 1024 * 1024 * 1024) {
+			return `${(sizeInBytes / (1024 * 1024)).toFixed(2)} MB`;
+		} else {
+			return `${(sizeInBytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+		}
+	};
+
+	// Convert a human-readable size string (e.g., "20 KB") to its size in bytes.
+	const parseFileSize = (sizeInString: string): number => {
+		// Regular expression to extract the numeric value and the unit
+
+		const regex = /([\d.]+)\s*(KB|MB|GB)/i;
+		const match = sizeInString.match(regex);
+
+		if (!match) {
+			throw new Error('Invalid file size format');
+		}
+
+		const value = parseFloat(match[1]); // Extract the numeric value
+		const unit = match[2].toUpperCase(); // Extract and normalize the unit
+
+		// Convert based on the unit
+		switch (unit) {
+			case 'KB':
+				return value * 1024;
+			case 'MB':
+				return value * 1024 * 1024;
+			case 'GB':
+				return value * 1024 * 1024 * 1024;
+			default:
+				throw new Error('Unknown unit');
+		}
+	};
+
+	return { formatFileSize, parseFileSize };
+}


### PR DESCRIPTION
The 'New Upload Modal' feature has been completed.

Implemented: 

1. General layout
2. File upload variants (“inProgress”, “completed”, “failed”)
3. Updating ProfileForm and SettingsPage based on the new upload modal.
4. Several functionalities: 
    - Upload button
    - Cancel button
    - Circular progress
    - Supported formats
    - Max file size
    - File size format


UI changes:

<img width="292" alt="1" src="https://github.com/user-attachments/assets/a4afb43a-3cfc-4718-b43a-05a5ba54f45f" />

<img width="293" alt="2" src="https://github.com/user-attachments/assets/d353177b-3871-4822-9c6b-e2ec41c72115" />

<img width="291" alt="3" src="https://github.com/user-attachments/assets/825618f1-483f-45c3-a90c-6fd7b931c7d8" />

<img width="292" alt="4" src="https://github.com/user-attachments/assets/63bdc139-4608-4d55-a81d-f504b36304eb" />

<img width="296" alt="5" src="https://github.com/user-attachments/assets/607129e3-4b5a-4b8a-9fab-31300b36df75" />


